### PR TITLE
Who Played Wednesday Addams? The Sinister Evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Who Played Wednesday Addams? The Sinister Evolution**
+
 The world of pop culture has countless iconic families. And the first collective that comes to many generations of people’s minds is none other than the Addams family, specifically the core members Morticia, Gomez, Wednesday, and Pugsley. Everything from their signature black attire to their creepy and kooky theme song (with necessary snapping) makes them continue to stand out from the TV and film fictional family crowd. And, it seems that we cannot get enough of the Addams family decades after their 1938 newspaper comic debut in The New Yorker. The latest Addams family content is Wednesday, a Netflix series centering around Morticia and Gomez’s fascinating daughter.
 
 MGM Television/Paramount Pictures/Netflix


### PR DESCRIPTION
The world of pop culture has countless iconic families. And the first collective that comes to many generations of people’s minds is none other than the Addams family, specifically the core members Morticia, Gomez, Wednesday, and Pugsley. Everything from their signature black attire to their creepy and kooky theme song (with necessary snapping) makes them continue to stand out from the TV and film fictional family crowd. And, it seems that we cannot get enough of the Addams family decades after their 1938 newspaper comic debut in The New Yorker. The latest Addams family content is Wednesday, a Netflix series centering around Morticia and Gomez’s fascinating daughter.

MGM Television/Paramount Pictures/Netflix Out of the entire family, Wednesday is the character who’s gone through the most evolutions. Her age and elements of her personality change with various portrayals. The Wednesday TV series is a major hit, giving us the delightfully dark teen we all love. So, let’s take a look at how Wednesday has changed over the many years, for better or worse, who has played Wednesday Addams, and where she’s at today.

Lisa Loring: Wednesday, the Child Full of Woe (or Not) Wednesday made her debut in the aforementioned Charles Addams comic. Like her family members, Wednesday did not have a name. These comics were one panel and, in most cases, it was the adults who did the talking. She appears to be quite young, between the ages of 6-8, and she’s simply a creepy looking kid with a dark streak. In the panels, Wednesday seems to be the same size (and presumably age) as Pugsley.

It’s not until the 1964 TV show, The Addams Family, where Charles Addams gave her the name Wednesday. His friend Joan Blake, an author and poet, was behind the name. Blake took it from the nursery rhyme line “Wednesday’s child is full of woe.” Interestingly, the first live-action version of Wednesday Addams (portrayed by Lisa Loring) isn’t creepy or kooky at all. Sure, she keeps the same general look with a black dress and two braided pigtails. https://mediaonline1.statuspage.io/ https://forum.webnovel.com/d/160924-media-news https://cinema21.site/ https://livesinema.com/ https://bingcinema.site/ https://open.firstory.me/user/clpmkq3mo01rl01wc6hu72o81 https://hse.microsoftcrmportals.com/forums/general-discussion/e354ec85-b3d7-ee11-a81c-000d3a6813a6 https://www.mohairdumas.com/group/mysite-231-group/discussion/cfc3b601-476b-46dc-9492-561a5fb7e1c1 https://github.com/DUNE-PART-TWO-s-Ending-Explained/DUNE-PART-TWO-s-Ending-Explained.git

lisa loring as wednesday addams tv and film evolution MGM Television But she’s very cute, quite the optimistic sweetie, and not nearly as “unconventional” as the rest of her family. Make no mistake, though. She’s quite odd in many ways with her love for spiders and headless dolls. In the show, she’s notably younger than her brother Pugsley and almost makes outsiders believe that the family is normal. That is, until they meet everyone and run from the house. It makes sense to have this little one be a general foil to everyone else. We love where she goes next.

Christina Ricci: The Dark Wednesday Addams Rises (and Stumbles) The next major live-action version we get of Wednesday Addams is in the early ‘90s with Christina Ricci’s portrayal of the character. Wednesday’s look and personality in The Addams Family and Addams Family Values movies is the “classic” one most fans think of. It shows her as a sinister teenager with a penchant for torturing her (now younger) brother.

We get some supremely sadistic Wednesday moments that expand on her comic foundation, from her burying a living cat to that infamous fire she encouraged at Camp Chippewa during that ridiculous Thanksgiving stage play. (No to killing cats. Yes to burning down the camp.)

Youtube Video play button

The 1960s TV show and the original newspaper cartoons frequently touch on some suspect things going down. However, Ricci’s Wednesday unambiguously turns up the violence. And, this is when she really became an icon to all the goth girls in the world. Her aesthetic and love for all things macabre, horror, and not “normal” is more than just a Halloween costume for many. It is a cornerstone of their authentic selves.

Ricci will play a role in the Wednesday series, but we will have to see what that entails. Of course, there were other notable live-action Wednesdays between Ricci’s run and Ortega’s fresh turn as the character. Broadway plays aged her up to adult without her classic ponytails, which is honestly kind of sad. Just like we need to see Morticia’s straight black hair and dress, we love Wednesday’s hairstyle choice no matter her age.

Nicole Fugere: A Chaotic Wednesday nicole fugere as wednesday addams in the new addams family show Fox Family Worldwide Nicole Fugere portrays Wednesday in the straight-to-video Addams Family Reunion film and the one season (with a ton of episodes) series The New Addams Family. This version of Wednesday didn’t resonate with the fans the same way as the sweet 1960s version nor Ricci’s teen nightmare. Sure, she was still a purveyor of chaos but it felt less menacing and deadpan.

Jenna Ortega: Wednesday Addams, the Superpowered Super Sleuth wednesday addams dance scene with jenna ortega in netflix series Netflix Decades later, the Addams family is back in the live-action TV business. And, Ortega’s Wednesday captures all the classic personality elements of this beloved baddie, including her deadpan humor. However, the show does give her some fun updates, including psychic powers that help her solve a series of murders happening around Nevermore Academy. While Morticia and other Addams family members have previously had various abilities that could be seen as supernatural (like the 1960s Morticia’s “smoking” or Granmama’s wild potions), Wednesday never had powers in her live-action iterations until now.

She was always far more intelligent and cunning than the average kid but she wasn’t making things float in the air. The Wednesday series also gave this teenage sleuth a lot more emotional range and even had her caught up in an almost-relationship. That is, until she found out the first boy she kissed is a Hyde. She cries for Thing, hugs her bestie Enid, and actually tells Gomez that he’s a great father.

However, she also nearly tortures Tyler in front of her classmates, dumps piranhas into a pool with mean boys, burns the statue of a racist, and still understandably loathes Thanksgiving. Some things never change! Interestingly, her relationship with Morticia seems to be more callous than previous iterations. It makes sense considering she’s older in this show compared to the ’60s show and Ricci’s movies. A 15-year-old (who turns 16 while at Nevermore) typically wants nothing to do with their mother.

It was a fresh and intriguing take on the character with more to come. The Netflix Wednesday show is coming back for another season so we can watch this version of her continue to evolve. One thing will always be for sure… Wednesday Addams is a child that you don’t trifle with in any way.